### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_BASE: /${{ github.event.repository.name }}/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deploy

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/1176b3bd-b42c-4f3a-a609-ed0b81c91f87) and click on Share -> Publish.
 
+### GitHub Pages
+
+1. Enable GitHub Pages in your repository settings.
+2. The included workflow `.github/workflows/deploy.yml` builds the project and publishes the `dist` folder to the `gh-pages` environment on every push to `main`.
+3. The build uses the repository name for the base path automatically. No manual edits are required.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/work" element={<Work />} />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,9 +2,14 @@
 const Hero = () => {
   return (
     <section className="pt-32 pb-24 px-8">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-3xl mx-auto text-center">
+        <img
+          src="/placeholder.svg"
+          alt="Portrait"
+          className="w-48 h-48 mx-auto rounded-full mb-8 object-cover"
+        />
         <h1 className="font-serif text-5xl md:text-7xl text-gray-900 mb-8 leading-tight">
-          Your Name
+          Rodrigo da Motta Cabral-Carvalho
         </h1>
         <p className="font-serif text-xl md:text-2xl text-gray-600 mb-12 leading-relaxed">
           Designer, Developer & Creative Thinker

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ const Navigation = () => {
       <div className="max-w-4xl mx-auto px-8 py-6">
         <div className="flex justify-between items-center">
           <Link to="/" className="font-serif text-xl text-gray-900 hover:text-gray-600 transition-colors">
-            Your Name
+            Rodrigo da Motta Cabral-Carvalho
           </Link>
           
           <div className="flex space-x-8">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,7 +16,7 @@ const Index = () => {
       <footer className="py-16 px-8">
         <div className="max-w-4xl mx-auto text-center">
           <p className="font-serif text-gray-500 mb-6">
-            © 2024 Your Name. All rights reserved.
+            © 2024 Rodrigo da Motta Cabral-Carvalho. All rights reserved.
           </p>
           <div className="flex justify-center space-x-8">
             <a href="#" className="font-serif text-gray-500 hover:text-gray-900 transition-colors">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: process.env.VITE_BASE || '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- support routing from subdirectories by using `import.meta.env.BASE_URL`
- allow Vite base path to be configured via the `VITE_BASE` environment variable
- add a workflow to build and deploy the site to GitHub Pages
- document the GitHub Pages process in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685053c8bf508320ba6e5e44cefd0ba8