### PR TITLE
Add blog post thumbnails

### DIFF
--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -10,6 +10,7 @@ const BlogPreview = () => {
       excerpt:
         'Reviewing self-report scales for subjective time using the Sentence-T5 transformer and clustering techniques.',
       date: '2024-05-01',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
     },
@@ -19,6 +20,7 @@ const BlogPreview = () => {
       excerpt:
         'Insights from organizing a 20-hour deep learning course at USP and covering the main topics successfully.',
       date: '2024-03-08',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
     },
@@ -29,6 +31,7 @@ const BlogPreview = () => {
       excerpt:
         'A look at ICA as a data-driven approach for separating linear contributions in EEG data.',
       date: '2024-02-15',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
     },
@@ -58,6 +61,21 @@ const BlogPreview = () => {
                 rel="noopener noreferrer"
                 className="block group"
               >
+                {post.image ? (
+                  <img
+                    src={post.image}
+                    alt={post.title}
+                    onError={(e) => {
+                      const target = e.currentTarget;
+                      if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                    }}
+                    className="w-full h-48 object-cover rounded mb-4"
+                  />
+                ) : (
+                  <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
+                    No image
+                  </div>
+                )}
                 <h3 className="font-serif text-2xl text-gray-900 mb-3 group-hover:text-gray-600 transition-colors">
                   {post.title}
                 </h3>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -12,6 +12,7 @@ const Blog = () => {
       date: '2024-05-01',
       readTime: '6 min read',
       tags: ['AI', 'LLMs', 'Psychology'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
       featured: true,
@@ -24,6 +25,7 @@ const Blog = () => {
       date: '2024-03-08',
       readTime: '8 min read',
       tags: ['AI', 'Education', 'Courses'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
       featured: false,
@@ -37,6 +39,7 @@ const Blog = () => {
       date: '2024-02-15',
       readTime: '5 min read',
       tags: ['Data Science', 'Neuroscience'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
       featured: false,
@@ -77,6 +80,21 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
+                  {featuredPost.image ? (
+                    <img
+                      src={featuredPost.image}
+                      alt={featuredPost.title}
+                      onError={(e) => {
+                        const target = e.currentTarget;
+                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                      }}
+                      className="w-full h-64 object-cover rounded mb-6"
+                    />
+                  ) : (
+                    <div className="w-full h-64 bg-gray-100 rounded mb-6 flex items-center justify-center text-gray-500">
+                      No image
+                    </div>
+                  )}
                   <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {featuredPost.title}
                   </h2>
@@ -129,6 +147,21 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
+                  {post.image ? (
+                    <img
+                      src={post.image}
+                      alt={post.title}
+                      onError={(e) => {
+                        const target = e.currentTarget;
+                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                      }}
+                      className="w-full h-48 object-cover rounded mb-4"
+                    />
+                  ) : (
+                    <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
+                      No image
+                    </div>
+                  )}
                   <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {post.title}
                   </h2>


### PR DESCRIPTION
## Summary
- add placeholder thumbnail path to each blog post
- render thumbnail image in BlogPreview and Blog pages
- include fallback to local placeholder if the provided URL fails

## Testing
- `npm run lint` *(fails: cannot find package and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68508c8c3d348320bafc6ed91e3feee4