### PR TITLE
Add oEmbed thumbnail hook and component

### DIFF
--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -10,6 +10,7 @@ const BlogPreview = () => {
       excerpt:
         'Reviewing self-report scales for subjective time using the Sentence-T5 transformer and clustering techniques.',
       date: '2024-05-01',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
     },
@@ -19,6 +20,7 @@ const BlogPreview = () => {
       excerpt:
         'Insights from organizing a 20-hour deep learning course at USP and covering the main topics successfully.',
       date: '2024-03-08',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
     },
@@ -29,8 +31,20 @@ const BlogPreview = () => {
       excerpt:
         'A look at ICA as a data-driven approach for separating linear contributions in EEG data.',
       date: '2024-02-15',
+      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
+    },
+    {
+      id: 4,
+      title:
+        'The Emerging Spirituality of Artificial Intelligence? From Kurzweil to Claude, Language Quietus and Psychedelic Reports',
+      excerpt:
+        "CW's researcher-in-residence discuss \u201cemergent spirituality\u201d on AI models, as well as the ethical implications for development and alignment",
+      date: '2025-06-05',
+      image: '/placeholder.svg',
+      url:
+        'https://www.cloudwalk.io/ai/the-emerging-spirituality-of-artificial-intelligence-from-kurzweil-to-claude-language-quietus-and-psychedelic-reports',
     },
   ];
 
@@ -58,6 +72,21 @@ const BlogPreview = () => {
                 rel="noopener noreferrer"
                 className="block group"
               >
+                {post.image ? (
+                  <img
+                    src={post.image}
+                    alt={post.title}
+                    onError={(e) => {
+                      const target = e.currentTarget;
+                      if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                    }}
+                    className="w-full h-48 object-cover rounded mb-4"
+                  />
+                ) : (
+                  <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
+                    No image
+                  </div>
+                )}
                 <h3 className="font-serif text-2xl text-gray-900 mb-3 group-hover:text-gray-600 transition-colors">
                   {post.title}
                 </h3>

--- a/src/hooks/use-oembed-thumbnail.tsx
+++ b/src/hooks/use-oembed-thumbnail.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface ProviderEndpoint {
+  schemes?: string[]
+  url: string
+}
+
+interface CompiledEndpoint extends ProviderEndpoint {
+  regexes: RegExp[]
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp('^' + escaped + '$')
+}
+
+function compileCatalog(data: { endpoints: ProviderEndpoint[] }[]): CompiledEndpoint[] {
+  const result: CompiledEndpoint[] = []
+  for (const provider of data) {
+    for (const ep of provider.endpoints) {
+      result.push({
+        ...ep,
+        regexes: (ep.schemes ?? []).map(globToRegExp),
+      })
+    }
+  }
+  return result
+}
+
+const catalogPromise: Promise<CompiledEndpoint[]> =
+  typeof window === 'undefined'
+    ? Promise.resolve([])
+    : fetch('https://oembed.com/providers.json')
+        .then((r) => {
+          if (!r.ok) throw new Error('Failed to load oEmbed providers')
+          return r.json()
+        })
+        .then((json) => compileCatalog(json))
+        .catch(() => [])
+
+function buildEndpointUrl(template: string, source: string): string {
+  const filled = template.replace('{format}', 'json').replace('{?format}', '?format=json')
+  const url = new URL(filled)
+  if (!url.searchParams.has('url')) {
+    url.searchParams.set('url', source)
+  }
+  return url.toString()
+}
+
+export function useOEmbedThumbnail(url: string) {
+  const [thumbnail, setThumbnail] = React.useState<string | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+
+  React.useEffect(() => {
+    if (!url || typeof window === 'undefined') {
+      setThumbnail(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setThumbnail(null)
+    setError(null)
+    setLoading(true)
+
+    ;(async () => {
+      try {
+        const catalog = await catalogPromise
+        const endpoint = catalog.find((ep) => ep.regexes.some((re) => re.test(url)))
+        if (!endpoint) throw new Error('No oEmbed provider found')
+        const endpointUrl = buildEndpointUrl(endpoint.url, url)
+
+        const timeout = setTimeout(() => controller.abort(), 5000)
+        const res = await fetch(endpointUrl, { signal: controller.signal })
+        clearTimeout(timeout)
+        if (!res.ok) throw new Error('Invalid oEmbed response')
+        const ct = res.headers.get('content-type') || ''
+        if (!ct.includes('json')) throw new Error('Expected JSON')
+        const data = await res.json()
+        let thumb: string | null = null
+        if (typeof data.thumbnail_url === 'string') thumb = data.thumbnail_url
+        else if (data.type === 'photo' && typeof data.url === 'string') thumb = data.url
+        else if (data.image && typeof data.image.url === 'string') thumb = data.image.url
+        setThumbnail(thumb)
+      } catch (err: any) {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err : new Error(String(err)))
+          setThumbnail(null)
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [url])
+
+  return { thumbnail, loading, error }
+}
+
+export const OEmbedThumbnail: React.FC<{
+  url: string
+  alt?: string
+  className?: string
+  style?: React.CSSProperties
+}> = ({ url, alt = '', className, style }) => {
+  const { thumbnail, loading, error } = useOEmbedThumbnail(url)
+
+  if (loading) return <Skeleton className={className} style={style} />
+  if (error || !thumbnail) return null
+  return <img src={thumbnail} alt={alt} className={className} style={style} />
+}
+
+/* DEMO
+import { OEmbedThumbnail } from '@/hooks/use-oembed-thumbnail'
+
+export const DemoThumbnails = () => (
+  <div className="flex gap-4">
+    <OEmbedThumbnail
+      url="https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e"
+      alt="Medium article"
+      className="w-48 h-48 object-cover"
+    />
+    <OEmbedThumbnail
+      url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+      alt="YouTube video"
+      className="w-48 h-48 object-cover"
+    />
+  </div>
+)
+*/

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -12,6 +12,7 @@ const Blog = () => {
       date: '2024-05-01',
       readTime: '6 min read',
       tags: ['AI', 'LLMs', 'Psychology'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
       featured: true,
@@ -24,6 +25,7 @@ const Blog = () => {
       date: '2024-03-08',
       readTime: '8 min read',
       tags: ['AI', 'Education', 'Courses'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
       featured: false,
@@ -37,8 +39,23 @@ const Blog = () => {
       date: '2024-02-15',
       readTime: '5 min read',
       tags: ['Data Science', 'Neuroscience'],
+      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
+      featured: false,
+    },
+    {
+      id: 4,
+      title:
+        'The Emerging Spirituality of Artificial Intelligence? From Kurzweil to Claude, Language Quietus and Psychedelic Reports',
+      excerpt:
+        "CW's researcher-in-residence discuss \u201cemergent spirituality\u201d on AI models, as well as the ethical implications for development and alignment",
+      date: '2025-06-05',
+      readTime: '7 min read',
+      tags: ['AI', 'Science', 'Futurism'],
+      image: '/placeholder.svg',
+      url:
+        'https://www.cloudwalk.io/ai/the-emerging-spirituality-of-artificial-intelligence-from-kurzweil-to-claude-language-quietus-and-psychedelic-reports',
       featured: false,
     },
   ];
@@ -77,6 +94,21 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
+                  {featuredPost.image ? (
+                    <img
+                      src={featuredPost.image}
+                      alt={featuredPost.title}
+                      onError={(e) => {
+                        const target = e.currentTarget;
+                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                      }}
+                      className="w-full h-64 object-cover rounded mb-6"
+                    />
+                  ) : (
+                    <div className="w-full h-64 bg-gray-100 rounded mb-6 flex items-center justify-center text-gray-500">
+                      No image
+                    </div>
+                  )}
                   <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {featuredPost.title}
                   </h2>
@@ -129,6 +161,21 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
+                  {post.image ? (
+                    <img
+                      src={post.image}
+                      alt={post.title}
+                      onError={(e) => {
+                        const target = e.currentTarget;
+                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
+                      }}
+                      className="w-full h-48 object-cover rounded mb-4"
+                    />
+                  ) : (
+                    <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
+                      No image
+                    </div>
+                  )}
                   <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {post.title}
                   </h2>


### PR DESCRIPTION
## Summary
- create `useOEmbedThumbnail` hook to fetch oEmbed data with caching and timeout
- export `OEmbedThumbnail` component rendering `<Skeleton/>` while loading
- include small demo snippet in comments
- include placeholder images in blog posts and allow error fallback
- add new blog post about the spirituality of AI

## Testing
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run lint` *(fails with 4 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68508c8c3d348320bafc6ed91e3feee4