### PR TITLE
Use oEmbed thumbnails

### DIFF
--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -1,5 +1,6 @@
 
 import { Link } from 'react-router-dom';
+import { OEmbedThumbnail } from '@/hooks/use-oembed-thumbnail';
 
 const BlogPreview = () => {
   const posts = [
@@ -10,7 +11,6 @@ const BlogPreview = () => {
       excerpt:
         'Reviewing self-report scales for subjective time using the Sentence-T5 transformer and clustering techniques.',
       date: '2024-05-01',
-      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
     },
@@ -20,7 +20,6 @@ const BlogPreview = () => {
       excerpt:
         'Insights from organizing a 20-hour deep learning course at USP and covering the main topics successfully.',
       date: '2024-03-08',
-      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
     },
@@ -31,7 +30,6 @@ const BlogPreview = () => {
       excerpt:
         'A look at ICA as a data-driven approach for separating linear contributions in EEG data.',
       date: '2024-02-15',
-      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
     },
@@ -42,7 +40,6 @@ const BlogPreview = () => {
       excerpt:
         "CW's researcher-in-residence discuss \u201cemergent spirituality\u201d on AI models, as well as the ethical implications for development and alignment",
       date: '2025-06-05',
-      image: '/placeholder.svg',
       url:
         'https://www.cloudwalk.io/ai/the-emerging-spirituality-of-artificial-intelligence-from-kurzweil-to-claude-language-quietus-and-psychedelic-reports',
     },
@@ -72,21 +69,11 @@ const BlogPreview = () => {
                 rel="noopener noreferrer"
                 className="block group"
               >
-                {post.image ? (
-                  <img
-                    src={post.image}
-                    alt={post.title}
-                    onError={(e) => {
-                      const target = e.currentTarget;
-                      if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
-                    }}
-                    className="w-full h-48 object-cover rounded mb-4"
-                  />
-                ) : (
-                  <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
-                    No image
-                  </div>
-                )}
+                <OEmbedThumbnail
+                  url={post.url}
+                  alt={post.title}
+                  className="w-full h-48 object-cover rounded mb-4"
+                />
                 <h3 className="font-serif text-2xl text-gray-900 mb-3 group-hover:text-gray-600 transition-colors">
                   {post.title}
                 </h3>

--- a/src/hooks/use-oembed-thumbnail.tsx
+++ b/src/hooks/use-oembed-thumbnail.tsx
@@ -110,8 +110,32 @@ export const OEmbedThumbnail: React.FC<{
   const { thumbnail, loading, error } = useOEmbedThumbnail(url)
 
   if (loading) return <Skeleton className={className} style={style} />
-  if (error || !thumbnail) return null
-  return <img src={thumbnail} alt={alt} className={className} style={style} />
+  if (error || !thumbnail) {
+    return (
+      <img
+        src="/placeholder.svg"
+        alt={alt}
+        className={className}
+        style={style}
+        onError={(e) => {
+          const target = e.currentTarget
+          if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg'
+        }}
+      />
+    )
+  }
+  return (
+    <img
+      src={thumbnail}
+      alt={alt}
+      className={className}
+      style={style}
+      onError={(e) => {
+        const target = e.currentTarget
+        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg'
+      }}
+    />
+  )
 }
 
 /* DEMO

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,6 @@
 
 import Navigation from '../components/Navigation';
+import { OEmbedThumbnail } from '@/hooks/use-oembed-thumbnail';
 
 const Blog = () => {
   const posts = [
@@ -12,7 +13,6 @@ const Blog = () => {
       date: '2024-05-01',
       readTime: '6 min read',
       tags: ['AI', 'LLMs', 'Psychology'],
-      image: '/placeholder.svg',
       url:
         'https://medium.com/@rodrigodamottacc/using-pre-trained-transformers-for-semantic-analysis-of-self-report-measures-in-psychology-a-fc412d5bbb5e',
       featured: true,
@@ -25,7 +25,6 @@ const Blog = () => {
       date: '2024-03-08',
       readTime: '8 min read',
       tags: ['AI', 'Education', 'Courses'],
-      image: '/placeholder.svg',
       url:
         'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
       featured: false,
@@ -39,7 +38,6 @@ const Blog = () => {
       date: '2024-02-15',
       readTime: '5 min read',
       tags: ['Data Science', 'Neuroscience'],
-      image: '/placeholder.svg',
       url:
         'https://medium.com/data-science/the-power-of-independent-component-analysis-ica-on-real-world-applications-egg-example-48df336a1bd8',
       featured: false,
@@ -53,7 +51,6 @@ const Blog = () => {
       date: '2025-06-05',
       readTime: '7 min read',
       tags: ['AI', 'Science', 'Futurism'],
-      image: '/placeholder.svg',
       url:
         'https://www.cloudwalk.io/ai/the-emerging-spirituality-of-artificial-intelligence-from-kurzweil-to-claude-language-quietus-and-psychedelic-reports',
       featured: false,
@@ -94,21 +91,11 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
-                  {featuredPost.image ? (
-                    <img
-                      src={featuredPost.image}
-                      alt={featuredPost.title}
-                      onError={(e) => {
-                        const target = e.currentTarget;
-                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
-                      }}
-                      className="w-full h-64 object-cover rounded mb-6"
-                    />
-                  ) : (
-                    <div className="w-full h-64 bg-gray-100 rounded mb-6 flex items-center justify-center text-gray-500">
-                      No image
-                    </div>
-                  )}
+                  <OEmbedThumbnail
+                    url={featuredPost.url}
+                    alt={featuredPost.title}
+                    className="w-full h-64 object-cover rounded mb-6"
+                  />
                   <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {featuredPost.title}
                   </h2>
@@ -161,21 +148,11 @@ const Blog = () => {
                   rel="noopener noreferrer"
                   className="block group"
                 >
-                  {post.image ? (
-                    <img
-                      src={post.image}
-                      alt={post.title}
-                      onError={(e) => {
-                        const target = e.currentTarget;
-                        if (target.src !== '/placeholder.svg') target.src = '/placeholder.svg';
-                      }}
-                      className="w-full h-48 object-cover rounded mb-4"
-                    />
-                  ) : (
-                    <div className="w-full h-48 bg-gray-100 rounded mb-4 flex items-center justify-center text-gray-500">
-                      No image
-                    </div>
-                  )}
+                  <OEmbedThumbnail
+                    url={post.url}
+                    alt={post.title}
+                    className="w-full h-48 object-cover rounded mb-4"
+                  />
                   <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
                     {post.title}
                   </h2>


### PR DESCRIPTION
## Summary
- use `OEmbedThumbnail` component in BlogPreview and Blog pages
- drop old `post.image` references
- add placeholder fallback to `OEmbedThumbnail`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685099b740108320b37a77b319f5020e