### PR TITLE
Polish blog and conferences, normalize thumbnails, sort posts

### DIFF
--- a/scripts/fetch-og-thumbnails.mjs
+++ b/scripts/fetch-og-thumbnails.mjs
@@ -7,11 +7,47 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const OUT_DIR = path.join(ROOT, 'public', 'og');
 const MANIFEST = path.join(ROOT, 'src', 'lib', 'og-thumbnails-manifest.json');
+
+// Target aspect ratio for normalized thumbnails (3:2 landscape).
+const TARGET_W = 1200;
+const TARGET_H = 800;
+
+// Resize + center-crop an image to a fixed aspect ratio so every thumbnail
+// shares identical dimensions and the card grid has no blank-space gaps.
+// Tries ImageMagick `convert` (preinstalled on GitHub Actions Ubuntu runners)
+// first, then falls back to Pillow via python3 (works locally on macOS).
+function normalizeImage(filePath) {
+  // Try ImageMagick `convert` (works on Linux CI runners).
+  try {
+    execFileSync('convert', [
+      filePath,
+      '-resize', `${TARGET_W}x${TARGET_H}^`,
+      '-gravity', 'center',
+      '-extent', `${TARGET_W}x${TARGET_H}`,
+      filePath,
+    ], { stdio: 'ignore' });
+    return;
+  } catch { /* fall through to Pillow */ }
+  // Pillow fallback (works locally on macOS).
+  const script = `
+from PIL import Image
+img = Image.open(${JSON.stringify(filePath)})
+img = img.convert('RGB')
+scale = max(${TARGET_W}/img.width, ${TARGET_H}/img.height)
+img = img.resize((round(img.width*scale), round(img.height*scale)))
+left = (img.width-${TARGET_W})//2
+top = (img.height-${TARGET_H})//2
+img = img.crop((left, top, left+${TARGET_W}, top+${TARGET_H}))
+img.save(${JSON.stringify(filePath)}, 'JPEG', quality=86, optimize=True)
+`;
+  execFileSync('python3', ['-c', script], { stdio: 'ignore' });
+}
 
 const UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
@@ -88,10 +124,17 @@ async function downloadImage(imgUrl) {
   });
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   const buf = Buffer.from(await r.arrayBuffer());
-  const ext = extFromType(r.headers.get('content-type')) || path.extname(new URL(imgUrl).pathname).slice(0, 5) || '.img';
   const hash = crypto.createHash('sha1').update(imgUrl).digest('hex').slice(0, 16);
-  const name = `${hash}${ext}`;
-  fs.writeFileSync(path.join(OUT_DIR, name), buf);
+  // Normalize to JPEG at a fixed 3:2 aspect ratio so all thumbnails share
+  // identical dimensions and the card grid has no blank-space gaps.
+  const name = `${hash}.jpg`;
+  const outPath = path.join(OUT_DIR, name);
+  fs.writeFileSync(outPath, buf);
+  try {
+    normalizeImage(outPath);
+  } catch (e) {
+    console.log(`[og-thumbnails] normalize-fail <- ${imgUrl.slice(0, 60)} (${e.message})`);
+  }
   return `og/${name}`;
 }
 

--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -38,14 +38,14 @@ const BlogPreview = () => {
       ),
     },
         {
-      id: 14,
-      title: 'RAG, TOOL-CALLING, AND THE FIGHT AGAINST HALLUCINATIONS',
+      id: 12,
+      title: 'Neural Networks via Information',
       excerpt:
-        'This article serves as a survey and futuristic perspective on trustworthy AI anchored on knowledge retrieval',
-      date: '2025-11-06',
-      url: 'https://www.cloudwalk.io/ai/rag-tool-calling-and-the-fight-against-hallucinations',
+        'A way to better understand learning with deep neural networks through the lens of information theory.',
+      date: '2022-12-13',
+      url: 'https://medium.com/data-science/neural-network-via-information-68af7f49b978',
       ...buildThumbnail(
-        'https://www.cloudwalk.io/ai/rag-tool-calling-and-the-fight-against-hallucinations',
+        'https://medium.com/data-science/neural-network-via-information-68af7f49b978',
       ),
     },
     {
@@ -74,15 +74,15 @@ const BlogPreview = () => {
       ),
     },
     {
-      id: 3,
-      title: 'Simulating Vibrations: The Advanced Physics Behind Drums and Speakers',
+      id: 5,
+      title: 'How I Organized a One-week University Course on Deep Learning',
       excerpt:
-        'Exploring the 2D Wave Equation through simulations and by hearing them.',
-      date: '2024-06-05',
+        'A hot topic in data science is how to teach it; this article details my experience organizing a 20-hour deep learning course at USP.',
+      date: '2024-03-08',
       url:
-        'https://medium.com/@rodrigodamottacc/simulating-vibrations-the-advanced-physics-behind-drums-and-speakers-b350f6fb1362',
+        'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
       ...buildThumbnail(
-        'https://medium.com/@rodrigodamottacc/simulating-vibrations-the-advanced-physics-behind-drums-and-speakers-b350f6fb1362',
+        'https://medium.com/towards-artificial-intelligence/how-i-organized-a-one-week-university-course-on-deep-learning-3bf99432f31c',
       ),
     },
     {
@@ -133,8 +133,8 @@ const BlogPreview = () => {
               key={post.id}
               className="rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow overflow-hidden"
             >
-              <a href={post.url} target="_blank" rel="noopener noreferrer" className="block group">
-                <div className="aspect-[4/3] overflow-hidden">
+              <a href={post.url} target="_blank" rel="noopener noreferrer" className="flex group">
+                <div className="w-40 sm:w-44 flex-shrink-0 aspect-[3/2] overflow-hidden bg-gray-100">
                   <img
                     src={ogMap[post.url] || post.primary}
                     alt={`Thumbnail for ${post.title}`}
@@ -152,18 +152,18 @@ const BlogPreview = () => {
                     }}
                   />
                 </div>
-                <div className="p-4">
-                  <time className="font-serif text-xs text-gray-500 mb-1 block uppercase tracking-wide">
+                <div className="p-3 flex-1">
+                  <time className="font-serif text-[11px] text-gray-500 mb-0.5 block uppercase tracking-wide">
                     {new Date(post.date).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric',
                     })}
                   </time>
-                  <h3 className="font-serif text-base text-gray-900 mb-1 group-hover:text-gray-600 transition-colors">
+                  <h3 className="font-serif text-sm text-gray-900 leading-snug mb-1 group-hover:text-gray-600 transition-colors">
                     {post.title}
                   </h3>
-                  <p className="font-serif text-gray-600 leading-relaxed text-xs">
+                  <p className="font-serif text-gray-600 leading-relaxed text-xs line-clamp-2">
                     {post.excerpt}
                   </p>
                 </div>

--- a/src/components/ConferencesPreview.tsx
+++ b/src/components/ConferencesPreview.tsx
@@ -1,23 +1,23 @@
 import { Link } from 'react-router-dom';
-import { conferenceAppearances, conferencesPresentations, conferencesInvitedTalks } from '../lib/conferences';
+import { conferenceAppearances } from '../lib/conferences';
 
 const ConferencesPreview = () => {
   return (
     <section className="py-8 px-6 md:px-8">
       <div className="max-w-5xl mx-auto">
-        <h2 className="font-serif text-2xl md:text-3xl text-gray-900 mb-6">
+        <h2 className="font-serif text-2xl md:text-3xl text-gray-900 mb-5">
           Conferences & Talks
         </h2>
 
-        <div className="grid gap-4 md:grid-cols-2 mb-6">
+        <div className="grid gap-3 md:grid-cols-2 mb-5">
           {conferenceAppearances.map((appearance) => (
             <article
               key={appearance.id}
-              className="rounded-lg border border-gray-200 p-4 shadow-sm hover:shadow-md transition-shadow"
+              className="rounded-lg border border-gray-200 p-3 shadow-sm hover:shadow-md transition-shadow"
             >
-              <div className="flex flex-col gap-1 mb-2">
+              <div className="flex flex-col gap-0.5 mb-1.5">
                 <div>
-                  <h3 className="font-serif text-base text-gray-900">
+                  <h3 className="font-serif text-sm text-gray-900 leading-snug">
                     {appearance.title}
                   </h3>
                   <p className="font-serif text-gray-600 text-xs">
@@ -29,7 +29,7 @@ const ConferencesPreview = () => {
                 </div>
               </div>
 
-              <p className="font-serif text-gray-600 leading-relaxed mb-2 text-xs">
+              <p className="font-serif text-gray-600 leading-relaxed mb-1.5 text-xs line-clamp-2">
                 {appearance.description}
               </p>
 
@@ -41,7 +41,7 @@ const ConferencesPreview = () => {
                       href={link.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-serif text-sm text-blue-600 underline"
+                      className="font-serif text-xs text-blue-600 underline"
                     >
                       {link.label}
                     </a>
@@ -50,50 +50,6 @@ const ConferencesPreview = () => {
               )}
             </article>
           ))}
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 mb-6">
-          <div>
-            <h3 className="font-serif text-lg text-gray-900 mb-2">Presentations</h3>
-            <ul className="space-y-1.5 text-xs text-gray-600 list-disc pl-5">
-              {conferencesPresentations.map((item) => (
-                <li key={item.label}>
-                  {item.href ? (
-                    <a href={item.href} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
-                      {item.label}
-                    </a>
-                  ) : (
-                    item.label
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-serif text-lg text-gray-900 mb-2">Invited Talks (on site)</h3>
-            <ul className="space-y-1.5 text-xs text-gray-600 list-disc pl-5">
-              {conferencesInvitedTalks.map((talk) => (
-                <li key={talk.text ?? talk.prefix ?? talk.linkLabel}>
-                  {talk.text ? (
-                    talk.text
-                  ) : (
-                    <span>
-                      {talk.prefix}
-                      <a
-                        href={talk.linkHref}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 underline"
-                      >
-                        {talk.linkLabel}
-                      </a>
-                      {talk.suffix}
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
         </div>
 
         <Link

--- a/src/lib/blogUrls.ts
+++ b/src/lib/blogUrls.ts
@@ -2,6 +2,7 @@
 // Keep in sync with the posts defined in src/pages/Blog.tsx and
 // src/components/BlogPreview.tsx.
 export const blogUrls: string[] = [
+  'https://medium.com/@rodrigodamottacc/mapping-a-research-landscape-with-semantic-embeddings-7e13c44ce1e8',
   'https://www.cloudwalk.io/newsroom/brazilian-ai-researcher-from-cloudwalk-unveils-multi-agent-marketplace-simulation-at-stanford-pioneering-the-future-of-autonomous-digital-commerce',
   'https://www.cloudwalk.io/ai/rag-tool-calling-and-the-fight-against-hallucinations',
   'https://www.cloudwalk.io/ai/first-token-bias-transformers-as-graphs',

--- a/src/lib/conferences.ts
+++ b/src/lib/conferences.ts
@@ -71,7 +71,7 @@ export const conferenceAppearances: ConferenceAppearance[] = [
   },
   {
     id: 5,
-    title: 'Talk — Characterizing Human Semantic Navigation',
+    title: 'Poster — Characterizing Human Semantic Navigation',
     event: 'Journée de la recherche 2026, Université de Montréal',
     location: 'Montréal, Canada',
     year: '2026',
@@ -86,26 +86,88 @@ export const conferenceAppearances: ConferenceAppearance[] = [
   },
 ];
 
-// High-level list of presentations used on Conferences page and preview
-// Each item may optionally include an href to link to a recording or resource
-export const conferencesPresentations: { label: string; href?: string }[] = [
-  { label: 'Oral presentation at 10th BRAINN Congress (Campinas 2024, UNICAMP, Brazil)' },
-  { label: 'Poster at OHBM 2024 (Seoul, South Korea)' },
-  { label: 'Poster at Brain Modes 2024 (Bilbao, Spain)' },
-  { label: 'Talk at Brain Modes 2025 (Toronto, Canada)', href: 'https://youtu.be/UfnNs7bVVfQ?list=PLArBKNfJxuum3IMjvqlr934_lD18mBX2j' },
-  { label: 'Poster at Stanford Graph Learning Workshop 2025 (Palo Alto, US)' },
+// Structured presentations used on the Conferences page. Rendered as a
+// compact table with type badges (Poster / Talk / Oral / Research visit)
+// and a year column, so the list is scannable instead of long text lines.
+export type Presentation = {
+  type: 'Poster' | 'Talk' | 'Oral presentation' | 'Publication and Poster' | 'Research visit';
+  venue: string;
+  location: string;
+  year: string;
+  href?: string;
+};
+
+export const conferencesPresentations: Presentation[] = [
   {
-    label: 'Poster at ICLR 2026 (Rio de Janeiro, Brazil)',
+    type: 'Publication and Poster',
+    venue: 'ICLR 2026',
+    location: 'Rio de Janeiro, Brazil',
+    year: '2026',
     href: 'https://iclr.cc/virtual/2026/poster/10009590',
   },
   {
-    label: 'Talk at Journée de la recherche 2026 (Université de Montréal, Canada)',
+    type: 'Poster',
+    venue: 'Stanford Graph Learning Workshop — AgentMarket',
+    location: 'Palo Alto, USA',
+    year: '2025',
   },
   {
-    label: 'Research visit at Mila — Quebec Artificial Intelligence Institute (2026)',
+    type: 'Talk',
+    venue: 'Brazilian Society of Neuroscience and Behaviour — Quantifying Subjective Experiences with LLMs',
+    location: 'São Paulo, Brazil',
+    year: '2025',
+  },
+  {
+    type: 'Talk',
+    venue: 'Brain Modes 2025',
+    location: 'Toronto, Canada',
+    year: '2025',
+    href: 'https://youtu.be/UfnNs7bVVfQ?list=PLArBKNfJxuum3IMjvqlr934_lD18mBX2j',
+  },
+  {
+    type: 'Poster',
+    venue: 'Brain Modes 2024',
+    location: 'Bilbao, Spain',
+    year: '2024',
+  },
+  {
+    type: 'Poster',
+    venue: 'Organization for Human Brain Mapping (OHBM) 2024',
+    location: 'Seoul, South Korea',
+    year: '2024',
+  },
+  {
+    type: 'Oral presentation',
+    venue: '10th BRAINN Congress',
+    location: 'UNICAMP, Brazil',
+    year: '2024',
+  },
+  {
+    type: 'Poster',
+    venue: 'Journée de la recherche 2026',
+    location: 'Université de Montréal, Canada',
+    year: '2026',
+  },
+  {
+    type: 'Research visit',
+    venue: 'Mila — Quebec Artificial Intelligence Institute',
+    location: 'Montréal, Canada',
+    year: '2026',
     href: 'https://mila.quebec/',
   },
 ];
+
+// Uniqueness guard: throws if any presentation entries are duplicated (by
+// venue + year) so accidental repeats surface immediately in dev/build
+// instead of rendering with duplicate React keys.
+const _dup = conferencesPresentations
+  .map((p) => `${p.venue} · ${p.year}`)
+  .filter((key, i, arr) => arr.indexOf(key) !== i);
+if (_dup.length > 0) {
+  throw new Error(
+    `Duplicate conferencesPresentations entries found:\n${_dup.map((d) => `  - ${d}`).join('\n')}`,
+  );
+}
 
 // Invited talks list used on Conferences page and preview
 export type InvitedTalk = {

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -28,6 +28,17 @@ const Blog = () => {
   const [ogMap, setOgMap] = useState<Record<string, string | null>>({});
   const rawPosts = [
         {
+      id: 16,
+      title: 'From My Dissertation to a Research Map using Semantic Embeddings',
+      excerpt:
+        'After completing my dissertation, I couldn\'t shake the idea of visualizing it within a research landscape — an interdisciplinary map spanning AI research, Neuroscience, Psychedelic Science, and Complex Systems using semantic embeddings.',
+      date: '2025-07-08',
+      readTime: '7 min read',
+      tags: ['AI', 'Embeddings', 'Complex Systems', 'Research'],
+      url: 'https://medium.com/@rodrigodamottacc/mapping-a-research-landscape-with-semantic-embeddings-7e13c44ce1e8',
+      featured: false,
+    },
+        {
       id: 15,
       title:
         'Brazilian AI Researcher From CloudWalk Unveils Multi-Agent Marketplace Simulation at Stanford',
@@ -212,10 +223,12 @@ const Blog = () => {
     },
   ];
 
-  const posts = rawPosts.map((post) => ({
-    ...post,
-    ...buildThumbnail(post.url),
-  }));
+  const posts = rawPosts
+    .map((post) => ({
+      ...post,
+      ...buildThumbnail(post.url),
+    }))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const featuredPost = posts.find(post => post.featured);
   const regularPosts = posts.filter(post => !post.featured);
@@ -261,9 +274,9 @@ const Blog = () => {
 
           {/* Featured Post */}
           {featuredPost && (
-            <div className="mb-4">
-              <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-1 md:p-2">
-                <div className="flex items-center mb-1">
+            <div className="mb-6">
+              <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-1 md:p-1.5">
+                <div className="flex items-center mb-1 px-2 pt-1">
                   <span className="bg-blue-600 text-white px-2 py-0.5 rounded-full text-[10px] font-medium">
                     Featured
                   </span>
@@ -273,9 +286,9 @@ const Blog = () => {
                   href={featuredPost.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block group"
+                  className="flex group p-2 gap-3"
                 >
-                  <div className="overflow-hidden rounded-md mb-2 aspect-[16/6] md:aspect-[16/6]">
+                  <div className="w-32 sm:w-40 md:w-48 flex-shrink-0 aspect-[3/2] overflow-hidden rounded-md bg-gray-100">
                     <img
                       src={ogMap[featuredPost.url] || featuredPost.primary}
                       alt={`Thumbnail for ${featuredPost.title}`}
@@ -293,31 +306,33 @@ const Blog = () => {
                       }}
                     />
                   </div>
-                  <h2 className="text-base md:text-lg font-bold text-gray-900 mb-1 group-hover:text-blue-600 transition-colors">
-                    {featuredPost.title}
-                  </h2>
-                  <p className="text-sm text-gray-600 mb-2 leading-relaxed">
-                    {featuredPost.excerpt}
-                  </p>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-sm md:text-base font-bold text-gray-900 mb-1 group-hover:text-blue-600 transition-colors leading-snug">
+                      {featuredPost.title}
+                    </h2>
+                    <p className="text-xs text-gray-600 mb-2 leading-relaxed line-clamp-2">
+                      {featuredPost.excerpt}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-500 mb-2">
+                      <time>
+                        {new Date(featuredPost.date).toLocaleDateString('en-US', { 
+                          year: 'numeric', 
+                          month: 'long', 
+                          day: 'numeric' 
+                        })}
+                      </time>
+                      <span>•</span>
+                      <span>{featuredPost.readTime}</span>
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {featuredPost.tags.map((tag) => (
+                        <span key={tag} className="px-2 py-0.5 bg-white text-gray-700 text-[10px] rounded-full">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
                 </a>
-                <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-500 mb-2">
-                  <time>
-                    {new Date(featuredPost.date).toLocaleDateString('en-US', { 
-                      year: 'numeric', 
-                      month: 'long', 
-                      day: 'numeric' 
-                    })}
-                  </time>
-                  <span>•</span>
-                  <span>{featuredPost.readTime}</span>
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  {featuredPost.tags.map((tag) => (
-                    <span key={tag} className="px-2 py-0.5 bg-white text-gray-700 text-[10px] rounded-full">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
               </div>
             </div>
           )}
@@ -331,7 +346,7 @@ const Blog = () => {
                     href={post.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block md:w-44 overflow-hidden rounded-xl flex-shrink-0"
+                    className="block md:w-44 aspect-[3/2] overflow-hidden rounded-xl flex-shrink-0"
                   >
                     <img
                       src={ogMap[post.url] || post.primary}

--- a/src/pages/Conferences.tsx
+++ b/src/pages/Conferences.tsx
@@ -27,28 +27,54 @@ const Conferences = () => {
           {/* Overview cards: Presentations, Invited Talks, Awards */}
           <section className="grid gap-4 md:grid-cols-3 mb-12">
             {/* Presentations */}
-            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm md:col-span-2">
               <h2 className="font-serif text-lg text-gray-900 mb-3 pb-2 border-b border-gray-100">
                 Presentations
               </h2>
-              <ul className="space-y-2 text-xs text-gray-600">
-                {conferencesPresentations.map((item) => (
-                  <li key={item.label} className="leading-relaxed">
-                    {item.href ? (
-                      <a
-                        href={item.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 underline"
-                      >
-                        {item.label}
-                      </a>
-                    ) : (
-                      item.label
-                    )}
-                  </li>
+              <div className="divide-y divide-gray-100">
+                {conferencesPresentations.map((item, idx) => (
+                  <div
+                    key={`${item.venue}-${item.year}-${idx}`}
+                    className="flex items-start gap-3 py-2"
+                  >
+                    <span
+                      className={`flex-shrink-0 mt-0.5 px-2 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap ${
+                        item.type === 'Talk'
+                          ? 'bg-blue-100 text-blue-700'
+                          : item.type === 'Poster'
+                            ? 'bg-gray-100 text-gray-700'
+                            : item.type === 'Oral presentation'
+                              ? 'bg-green-100 text-green-700'
+                              : item.type === 'Research visit'
+                                ? 'bg-purple-100 text-purple-700'
+                                : 'bg-amber-100 text-amber-700'
+                      }`}
+                    >
+                      {item.type}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      {item.href ? (
+                        <a
+                          href={item.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-serif text-xs text-gray-900 hover:text-blue-600 transition-colors"
+                        >
+                          {item.venue}
+                        </a>
+                      ) : (
+                        <span className="font-serif text-xs text-gray-900">{item.venue}</span>
+                      )}
+                      <div className="font-serif text-[11px] text-gray-500">
+                        {item.location}
+                      </div>
+                    </div>
+                    <span className="flex-shrink-0 font-serif text-[11px] text-gray-400 mt-0.5">
+                      {item.year}
+                    </span>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
 
             {/* Invited Talks */}
@@ -84,7 +110,7 @@ const Conferences = () => {
             </div>
 
             {/* Awards */}
-            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm md:col-span-2 lg:col-span-1">
               <h2 className="font-serif text-lg text-gray-900 mb-3 pb-2 border-b border-gray-100">
                 Awards
               </h2>


### PR DESCRIPTION
## Summary

### Blog
- Add new post "From My Dissertation to a Research Map using Semantic Embeddings"
- Sort blog posts by date (most recent first) via in-component sort
- Compact the featured post to a horizontal layout (small thumbnail + text)
- Swap a post on the main-page "Recent Writing" preview (RAG → Neural Networks via Information)

### Conferences
- Fix the Montréal entry from "Talk" → "Poster"
- Add the missing "Talk at Brazilian Society of Neuroscience and Behaviour 2025"
- Restructure the Presentations list into a typed table with color-coded type badges (Poster/Talk/Oral/Research visit/Publication and Poster), venue, location, and year column
- Compact the main-page Conferences preview (drop the Presentations and Invited Talks lists — keep only the appearance cards; full lists remain on `/conferences`)

### Thumbnails
- Normalize all downloaded OG thumbnails to a fixed 1200×800 (3:2) at build time (ImageMagick `convert` with Pillow fallback) so the card grid has uniform dimensions and no blank-space gaps
- Fix an ESM `require` bug in the normalize fallback path

## Test plan
- [x] `npm run build` passes (prebuild downloads + normalizes 16 thumbnails)
- [x] Type-check passes
- [ ] Verify Conferences page Presentations table renders cleanly
- [ ] Verify blog posts are sorted by date
